### PR TITLE
Add ERC-20 support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,17 +86,29 @@ const createChannel = async () => {
     // Generate hashchain
     const hashchainArray = hashchain("initial-seed", numberOfTokens);
     const trustAnchor = hashchainArray[hashchainArray.length - 1];
-
-    const tx = await hashchainSDK.createChannel(
-      merchant,
-      token,
-      trustAnchor,
-      amount,
-      numberOfTokens,
-      merchantWithdrawAfterBlocks,
-      payerWithdrawAfterBlocks,
-      { value: amount }
-    );
+    let tx;
+    if (token === ethers.constants.AddressZero) {
+      tx = await hashchainSDK.createChannel(
+        merchant,
+        token,
+        trustAnchor,
+        amount,
+        numberOfTokens,
+        merchantWithdrawAfterBlocks,
+        payerWithdrawAfterBlocks,
+        { value: amount }
+      );
+    } else {
+      tx = await hashchainSDK.createChannel(
+        merchant,
+        token,
+        trustAnchor,
+        amount,
+        numberOfTokens,
+        merchantWithdrawAfterBlocks,
+        payerWithdrawAfterBlocks
+      );
+    }
 
     console.log("\n📤 Transaction sent! Hash:", tx.hash);
     const receipt = await tx.wait();


### PR DESCRIPTION
### Changes
- Added ERC-20 token support to `createChannel`. ETH payments are handled by checking if the token is the zero address and sending value accordingly.
- Updated `redeemChannel` and `reclaimChannel` to require a `token` parameter (e.g., zero address for ETH).

### ⚠️ Breaking Change
- Token address is now a required parameter for all channel operations.
- For native token payments, callers must explicitly pass the zero address (`0x000...000`).
