### PR TITLE
Add ERC-20 Token Allowance Handling to SDK

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -59,8 +59,18 @@ export class HashchainProtocol {
 
     // Handle native vs token logic here
     const isNative = tokenAddress === ethers.constants.AddressZero;
-    // if (!isNative) {
-    // }
+
+    // Check allowance if token is not native token
+    if (!isNative) {
+      const allowance = await this.checkAllowance(tokenAddress);
+
+      // If allowance is less than the amount, throw an error
+      if (allowance.lt(amount)) {
+        throw new Error(
+          "InsufficientAllowanceError: Please approve tokens first."
+        );
+      }
+    }
     const txOverrides = isNative ? { ...overrides, value: amount } : overrides;
 
     try {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,5 +1,5 @@
-import { ethers } from "ethers";
-import { hashchain, decodeContractError } from "./utils";
+import { ethers, BigNumber } from "ethers";
+import { decodeContractError, approveToken, getTokenAllowance } from "./utils";
 import HashchainProtocolABI from "../abis/HashchainProtocol.abi.json";
 import {
   CreateChannelParams,
@@ -59,6 +59,8 @@ export class HashchainProtocol {
 
     // Handle native vs token logic here
     const isNative = tokenAddress === ethers.constants.AddressZero;
+    // if (!isNative) {
+    // }
     const txOverrides = isNative ? { ...overrides, value: amount } : overrides;
 
     try {
@@ -128,6 +130,23 @@ export class HashchainProtocol {
         `Contract Error: ${decodedError?.errorName || "Unknown"} `
       );
     }
+  }
+
+  /**
+   * Approves the HashchainProtocol contract to spend a specified amount of ERC-20 tokens
+   * on behalf of the connected signer.
+   *
+   * @param {string} tokenAddress - The ERC-20 token contract address.
+   * @param {ethers.BigNumber} amount - The amount of tokens to approve.
+   * @returns {Promise<ethers.providers.TransactionResponse>} - The transaction response after sending the approval.
+   */
+  async approve(tokenAddress: string, amount: BigNumber) {
+    return await approveToken(
+      this.signer,
+      tokenAddress,
+      this.contract.address,
+      amount
+    );
   }
 
   /**

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -150,6 +150,21 @@ export class HashchainProtocol {
   }
 
   /**
+   * Retrieves the current ERC-20 token allowance that the HashchainProtocol contract
+   * has to spend on behalf of the connected signer.
+   *
+   * @param {string} tokenAddress - The ERC-20 token contract address.
+   * @returns {Promise<ethers.BigNumber>} - The allowance amount as a BigNumber.
+   */
+  async checkAllowance(tokenAddress: string): Promise<BigNumber> {
+    return await getTokenAllowance(
+      this.signer,
+      tokenAddress,
+      this.contract.address
+    );
+  }
+
+  /**
    * Verifies the integrity of a hashchain on-chain.
    *
    * @param trustAnchor - The initial hashchain value stored on-chain.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,3 +102,25 @@ export function decodeContractError(error: unknown, abi: JsonFragment[]) {
     return null;
   }
 }
+
+/**
+ * Approves a spender address to transfer a specified amount of ERC-20 tokens on behalf of the signer.
+ *
+ * @param {ethers.Signer} signer - The signer who owns the tokens and will send the approval transaction.
+ * @param {string} tokenAddress - The ERC-20 token contract address.
+ * @param {string} spender - The address allowed to spend the tokens (typically the smart contract address).
+ * @param {ethers.BigNumber} amount - The amount of tokens to approve.
+ * @returns {Promise<ethers.providers.TransactionResponse>} - The transaction response after sending the approval.
+ */
+export async function approveToken(
+  signer: ethers.Signer,
+  tokenAddress: string,
+  spender: string,
+  amount: ethers.BigNumber
+) {
+  const erc20Abi = [
+    "function approve(address spender, uint256 value) returns (bool)",
+  ];
+  const token = new ethers.Contract(tokenAddress, erc20Abi, signer);
+  return await token.approve(spender, amount);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,3 +124,24 @@ export async function approveToken(
   const token = new ethers.Contract(tokenAddress, erc20Abi, signer);
   return await token.approve(spender, amount);
 }
+
+/**
+ * Retrieves the current ERC-20 token allowance that the spender has for the signer's address.
+ *
+ * @param {ethers.Signer} signer - The signer whose allowance is being checked.
+ * @param {string} tokenAddress - The ERC-20 token contract address.
+ * @param {string} spender - The address of the contract or entity allowed to spend tokens.
+ * @returns {Promise<ethers.BigNumber>} - The current allowance amount as a BigNumber.
+ */
+export async function getTokenAllowance(
+  signer: ethers.Signer,
+  tokenAddress: string,
+  spender: string
+): Promise<ethers.BigNumber> {
+  const erc20Abi = [
+    "function allowance(address owner, address spender) view returns (uint256)",
+  ];
+  const token = new ethers.Contract(tokenAddress, erc20Abi, signer);
+  const owner = await signer.getAddress();
+  return await token.allowance(owner, spender);
+}


### PR DESCRIPTION
## Summary

This PR improves the SDK by adding ERC-20 allowance checks before contract calls to prevent reverts and improve UX.

## Changes

- Added utility functions: `approveToken` and `getTokenAllowance`
- Added `approve` and `checkAllowance` methods to `HashchainProtocol`
- Integrated allowance check into `createChannel`
    - Throws `InsufficientAllowanceError` if not enough allowance
- Added `approve` support to allow clients to grant ERC-20 allowance easily

Closes #8 
Closes #9 